### PR TITLE
Use updated multiparty dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "supervisor": "^0.6.0"
   },
   "dependencies": {
-    "multiparty": "~3.3.2"
+    "multiparty": "~4.2.2"
   },
   "engines": {
     "node": ">=0.10.3 <0.12"


### PR DESCRIPTION
It uses the new os.tmpdir() instead of os.tmpDir()